### PR TITLE
feat: Use local images for program score cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
 
         <a href="financial-literacy.html" class="program-card-link">
             <div class="program-card">
-                <img src="https://storage.googleapis.com/coresswc-media/financial-literacy.png" alt="Financial Literacy">
+                <img src="images/financial-literacy.png" alt="Financial Literacy">
                 <div class="program-card-content">
                     <h3>Financial Literacy</h3>
                     <p>Comprehensive financial education workshops and resources.</p>
@@ -44,7 +44,7 @@
 
         <a href="adopt-a-dap.html" class="program-card-link">
             <div class="program-card">
-                <img src="https://storage.googleapis.com/coresswc-media/adopt-a-dap.png" alt="Adopt-a-DAP">
+                <img src="images/adopt-a-dap.png" alt="Adopt-a-DAP">
                 <div class="program-card-content">
                     <h3>Adopt-a-DAP</h3>
                     <p>Support for families in need through our Adopt-a-DAP program.</p>
@@ -54,7 +54,7 @@
 
         <a href="fda-program.html" class="program-card-link">
             <div class="program-card">
-                <img src="https://storage.googleapis.com/coresswc-media/fda-program.png" alt="FDA Program">
+                <img src="images/fda-program.png" alt="FDA Program">
                 <div class="program-card-content">
                     <h3>FDA Program</h3>
                     <p>Financial Development Assistance for small businesses and entrepreneurs.</p>
@@ -64,7 +64,7 @@
 
         <a href="financial-aid.html" class="program-card-link">
             <div class="program-card">
-                <img src="https://storage.googleapis.com/coresswc-media/financial-aid.png" alt="Financial Aid Readiness">
+                <img src="images/financial-aid-readiness.jpg" alt="Financial Aid Readiness">
                 <div class="program-card-content">
                     <h3>Financial Aid Readiness</h3>
                     <p>Scholarship program to help students prepare for financial aid.</p>
@@ -74,7 +74,7 @@
 
         <a href="adult-literacy.html" class="program-card-link">
             <div class="program-card">
-                <img src="https://storage.googleapis.com/coresswc-media/adult-literacy.png" alt="Adult Literacy">
+                <img src="images/adult-literacy.png" alt="Adult Literacy">
                 <div class="program-card-content">
                     <h3>Adult Literacy</h3>
                     <p>Literacy programs for adults seeking to improve their reading and writing skills.</p>

--- a/jules-scratch/verification/verify_images.py
+++ b/jules-scratch/verification/verify_images.py
@@ -1,0 +1,30 @@
+import asyncio
+from playwright.async_api import async_playwright
+import os
+
+async def main():
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        page = await browser.new_page()
+
+        # Get the absolute path to the index.html file
+        file_path = os.path.abspath('index.html')
+
+        await page.goto(f'file://{file_path}')
+
+        # Wait for the images to load
+        await page.wait_for_selector('img[alt="Financial Literacy"]')
+        await page.wait_for_selector('img[alt="Adopt-a-DAP"]')
+        await page.wait_for_selector('img[alt="FDA Program"]')
+        await page.wait_for_selector('img[alt="Financial Aid Readiness"]')
+        await page.wait_for_selector('img[alt="Adult Literacy"]')
+
+        # Take a screenshot of the "Our Programs" section
+        element = await page.query_selector('.grid-3-cols')
+        if element:
+            await element.screenshot(path='jules-scratch/verification/verification.png')
+
+        await browser.close()
+
+if __name__ == '__main__':
+    asyncio.run(main())


### PR DESCRIPTION
Updates the `src` attributes of the `<img>` tags in the 'Our Programs' section of `index.html` to point to local image files in the `images/` directory. This replaces the previous implementation that used external URLs.